### PR TITLE
Fix so the logo only appears in the bottom right.

### DIFF
--- a/Aperture-Science.md
+++ b/Aperture-Science.md
@@ -16,7 +16,9 @@
 "cursorColor" : "#A66900",
 "experimental.retroTerminalEffect": true,
 "acrylicOpacity": 0.8,
-"backgroundImageOpacity": 0.8
+"backgroundImageOpacity": 0.8,
+"backgroundImageAlignment": "bottomRight",
+"backgroundImageStretchMode": "none"
 }
 ```
 


### PR DESCRIPTION
Source: https://www.reddit.com/r/Windows10/comments/gnqw1y/can_we_show_off_our_new_terminals/frg9p5p?utm_source=share&utm_medium=web2x